### PR TITLE
Change panel from min-width -> width (closes #8)

### DIFF
--- a/styles/panels.less
+++ b/styles/panels.less
@@ -34,7 +34,7 @@ atom-panel.modal {
 }
 
 atom-panel.modal > .select-list {
-  min-width: 500px;
+  width: 500px;
 }
 
 .inset-panel {


### PR DESCRIPTION
This seemed to fix the issue of the command-palette resizing for me. CSS isn't my strong suit and I've only tested this on my laptop (a 15" MBP), so I'm not entirely sure if this change would cause any other issue.