### PR TITLE
Update editor bg styling

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,8 +1,4 @@
 // Editor
-atom-text-editor, :host {
-  background: @base-background-color;
-}
-
 body {
   .transition;
 }


### PR DESCRIPTION
### Proposed change
Allow syntax theme to be declared by the syntax theme instead of the UI theme. This way the user can have a darker syntax theme with this UI theme.

### Issue
I was working late one night and wanted to use a darker theme, but didn't want to change my UI theme. After changing it I noticed that the UI theme was setting a base style, which overrides other themes. In this case it was a dark theme.

See attached screenshots:
**Before:**
<img width="592" alt="screen shot 2016-12-26 at 9 19 24 pm" src="https://cloud.githubusercontent.com/assets/1427854/21491702/883e54be-cbb3-11e6-9df6-3c4fa7f3e44d.png">
**After:**
<img width="594" alt="screen shot 2016-12-26 at 9 18 45 pm" src="https://cloud.githubusercontent.com/assets/1427854/21491704/8e584ecc-cbb3-11e6-8524-d734af9fd25b.png">

### Fix
Remove the `atom-text-editor, :host` selectors.
Since there are the same selectors in [apex-ui-slim](https://github.com/apex/apex-ui-slim/blob/master/styles/editor.less#L2) will probably need to update that also.

### Tested
Atom 1.12.7
macOS Sierra